### PR TITLE
:pencil2: update add options 'container' in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ var dockerdest = require('gulp-docker-dest');
 gulp.task('default', function () {
 	return gulp.src('src/*')
 		.pipe(dockerdest({
+			container: 'containerName',
 			remotePath: '/var/www/html'
 		}));
 });
@@ -31,6 +32,13 @@ gulp.task('default', function () {
 ## API
 
 ### dest(options)
+
+#### options.container
+
+Type: `string`
+Required
+
+The name of the container to copy to.
 
 #### options.remotePath
 


### PR DESCRIPTION
It looks like we were lacking this options in the documentation.

Going through the code it looks like there's a third options to control the log-level, but it's only affected by a flag when calling the plugin from the CLI. That's why I didn't add it here